### PR TITLE
Witruimte + global css

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -5,8 +5,10 @@
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<link href="https://fonts.googleapis.com/css2?family=Lusitana:wght@400;700&display=swap" rel="stylesheet">
+		
 
 		%sveltekit.head%
+		<link rel="stylesheet" href="%sveltekit.assets%/css/global.css">
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,7 @@
 </script>
  
 <!-- Only render if we have people in the data -->
-<section>
+<main>
     <div class="grid">
         {#if data.people}
         {#each data.people as person}
@@ -22,62 +22,58 @@
         <p>No data available</p>
         {/if}
     </div>
- 
-</section>
+</main>
 
 <style>
-    body{
-        margin: 0;
-    }
-section{
-    background-color: rgb(16, 36, 16);
-    max-width: 100%;
-    & .grid{
-        padding: 1em;
-        padding-top: 5em;
-        padding-bottom: 5em;
-        margin: 0 auto;
-        display: grid;
-        grid-template-columns: repeat(5, 1fr);
-        grid-template-rows: repeat(8, 1fr);
-        grid-column-gap: 32px;
-        grid-row-gap: 32px;
-        max-width: 1000px;
-    }
-    & article{
-        height: 220px;
-        padding: 32px;
-        border-radius: 1.5em;
-        padding: 1em;
-        background: url(card.png);
-        background-position: center;
-        background-size: 80%;
-        background-repeat: no-repeat;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        background-color: #ededed;
-        box-shadow: 5px 5px 10px rgb(9, 20, 9);
-        transform: scale(120%) rotate(-5deg) translateX(-10%) translateY(7%) ;
-            transition: ease-in 0.3s;
-        & img{
-            box-shadow: 2px 2px 4px rgba(131, 131, 131, 0.311);
-            border-radius: 100%;
-            object-fit: cover;
-        }
 
-        &:hover{
-            cursor: pointer;
-            
-            transform: scale(125%) rotate(3deg) translateX(-12%) translateY(-10%) ;
-            transition: ease-in 0.15s;
-            box-shadow: 5px 5px 10px rgb(29, 66, 29);
-            z-index: 5;
-            
+    main {
+        max-width: 100%;
+        & .grid{
+            padding: 1em;
+            padding-top: 5em;
+            padding-bottom: 5em;
+            margin: 0 auto;
+            display: grid;
+            grid-template-columns: repeat(5, 1fr);
+            grid-template-rows: repeat(8, 1fr);
+            grid-column-gap: 32px;
+            grid-row-gap: 32px;
+            max-width: 1000px;
         }
+        & article{
+            height: 220px;
+            padding: 32px;
+            border-radius: 1.5em;
+            padding: 1em;
+            background: url(card.png);
+            background-position: center;
+            background-size: 80%;
+            background-repeat: no-repeat;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            background-color: #ededed;
+            box-shadow: 5px 5px 10px rgb(9, 20, 9);
+            transform: scale(120%) rotate(-5deg) translateX(-10%) translateY(7%) ;
+                transition: ease-in 0.3s;
+            & img{
+                box-shadow: 2px 2px 4px rgba(131, 131, 131, 0.311);
+                border-radius: 100%;
+                object-fit: cover;
+            }
 
+            &:hover{
+                cursor: pointer;
+                
+                transform: scale(125%) rotate(3deg) translateX(-12%) translateY(-10%) ;
+                transition: ease-in 0.15s;
+                box-shadow: 5px 5px 10px rgb(29, 66, 29);
+                z-index: 5;
+                
+            }
+
+        }
     }
-}
 </style>
 

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -1,0 +1,9 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    background-color: rgb(16, 36, 16);
+}


### PR DESCRIPTION
# Issue: margins-layout
### Hoe het er eerst uitzag
![image](https://github.com/user-attachments/assets/6711ddec-d9f9-45c8-96f5-2d4856d77a8d)

De margin van de pagina weghalen
fixed #32 

## Wat ik heb gedaan
### Hoe het er nu uitziet
<img width="1680" alt="Scherm­afbeelding 2024-09-16 om 16 04 16" src="https://github.com/user-attachments/assets/56598d11-6574-4932-b639-239b284c1ef9">

- Witruimte is weg 
- global.css aangemaakt

## Waar te vinden
### HTML
https://github.com/ju5tu5/squadpage-sveltekit/blob/5698ab7f8c889ac029abd072a27ad0f3861f3c12/src/app.html#L9

### Mappen indeling
<img width="305" alt="Scherm­afbeelding 2024-09-16 om 16 05 29" src="https://github.com/user-attachments/assets/41c86439-8f7c-43fd-8914-376d7cfb5776">

De global.css is te vinden in de static map en is gelinkt in de app.html

